### PR TITLE
Version 2.0.0 Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,93 @@
 # ACF Icon Selector Field
 
-Allows you to create an 'icon-picker' acf-field.
+Allows you to create an 'nc-acf-icon-picker' acf-field.
 
 ---
 
 ## Description
 
-Add the svg icons you want to be available in your theme to an acf folder inside an img folder in your theme. The field returns the name of the svg.
+Add the svg icons you want to be available in your theme to an acf folder inside an img folder in your theme.
 
 ## Compatibility
 
-This ACF field type is compatible with:
-[x] ACF 5
-
-## Screenshots
-
-![Icon Picker](https://raw.githubusercontent.com/houke/acf-icon-picker/master/screenshots/example.png)
+This plugin has been tested with WordPress version 5.0 - 6.3.1
 
 ## Installation
 
 1. Copy the `acf-icon-picker` folder into your `wp-content/plugins` folder
 2. Activate the Icon Selector plugin via the plugins admin page
-3. Create a new field via ACF and select the Icon Selector type
+3. Create a new field via ACF and select the NC Icon Picker type
 
-## Filters
+## Adding Icons
 
-Use this filter in your theme's `functions.php` if you want to override the default icon folder. Returned path is relative to
-the current theme directory.
+By default, this plugin looks for SVG files in your theme's `images/svg-icons/` directory.
+The name of each icon shown in the picker will be the file name of its SVG file without the
+file's `.svg` extension. Icons will always be listed in alphabetical order.
 
-    add_filter( 'acf_icon_path_suffix', 'acf_icon_path_suffix' );
+## Retrieving an Icon Value
 
-    function acf_icon_path_suffix( $path_suffix ) {
-        return 'assets/img/icons/';
-    }
+When you retrieve the value of an `nc-acf-icon-picker` field using `get_field()`, the result
+is a JSON-encoded array with values for `icon` and `path`. You will be required to write your own
+code to convert those values to something useful to your context. For example, if your result
+from `get_field()` was the following (formatted for readability):
+
+```json
+{
+  "icon": "apple",
+  "path": "images/svg-icons/"
+}
+```
+
+You could create an image element by converting the JSON to a PHP array and combining the values into a `src` attribute:
+
+```php
+// This is not production code — proper code would include checks for valid JSON,
+// existing array keys, etc. It would also include, at the very least, an `alt` attribute on the image.
+$icon_value = json_decode( $raw_icon_value_from_acf );
+$icon_src = get_template_directory_uri() . '/' . $icon_value['path'] . $icon_value['icon'] . '.svg';
+?>
+<img src="<?php echo $icon_src; ?>" />
+
+```
+
+## Parent / Child Theme Icons
+
+If you are using a parent theme and one or more child themes, you can have a shared icon set in the parent theme
+and then override or supplement that set for each child theme. Icons in the parent theme's
+`images/svg-icons/` directory will be shared by all child themes. Icons in the child theme's
+`images/svg-icons/` directory will only be used for that specific child theme. If an icon with exactly the
+same file name is found in both the child theme and the parent theme, the child theme's version will be used.
+
+## Filters — Changing the Theme's Icon Directory
+
+Use the `nc_acf_icon_path_suffix` hook in your theme or plugin to override the default icon directory.
+Your filter function should return a path relative to the current theme directory.
+
+```
+add_filter( 'nc_acf_icon_path_suffix', 'nc_acf_icon_path_suffix' );
+
+function nc_acf_icon_path_suffix( $path_suffix ) {
+    return 'assets/icons/';
+}
+```
+
+This filter hook changes the icon for both the currently activated theme and the parent theme,
+if you are using one. To change the icon directory path for the parent theme separately, use the
+`nc_acf_icon_parent_path_suffix` hook as well.
 
 ## Changelog
 
-* 1.6.0 - Performance fix with lots of icons. Thanks to ![idflood](https://github.com/houke/acf-icon-picker/pull/9)
-* 1.5.0 - Fix issue where searching for icons would break preview if icon name has space
-* 1.4.0 - Add filter to change folder where svg icons are stored
-* 1.3.0 - Adding close option on modal
-* 1.2.0 - Adding search filter input to filter through icons by name
-* 1.1.0 - Add button to remove the selected icon when the field is not required
-* 1.0.0 - First release
+- 2.0.0 - **Major Update.** Before updating your copy of the plugin, review the following changes.
+
+  - Changed the field type name from `icon-picker` to `nc-acf-icon-picker` and updated its label from "Icon Picker" to "NC Icon Picker". Anywhere that you have
+    set up an icon picker field using this plugin, you must change the field's `type` value to `nc-acf-icon-picker`. If a field group is stored in code as JSON or PHP, you can make this change by changing the `type` value directly. If you are managing the field group directly within the ACF settings in WordPress, you will need to change the type to "NC Icon Picker".
+  - Changed the default path to icon files to `images/svg-icons/`. If you were using the old version of the plugin without modifying the path, you need to use the `nc_acf_icon_path_suffix` hook in your theme to change the path back to its old value (`assets/img/acf/`)
+  - Introduced parent/child theme support. Consult the "Parent / Child Theme Icons" section of this ReadMe for details on how to use this new feature.
+
+- 1.6.0 - Performance fix with lots of icons. Thanks to ![idflood](https://github.com/houke/acf-icon-picker/pull/9)
+- 1.5.0 - Fix issue where searching for icons would break preview if icon name has space
+- 1.4.0 - Add filter to change folder where svg icons are stored
+- 1.3.0 - Adding close option on modal
+- 1.2.0 - Adding search filter input to filter through icons by name
+- 1.1.0 - Add button to remove the selected icon when the field is not required
+- 1.0.0 - First release

--- a/acf-icon-picker.php
+++ b/acf-icon-picker.php
@@ -1,16 +1,12 @@
 <?php
 /*
 Plugin Name: Advanced Custom Fields: Icon Picker
-Plugin URI: https://github.com/houke/acf-icon-picker
 Plugin URI: https://github.com/newcity/acf-icon-picker
 Description: Allows you to pick an icon from a predefined list
-Version: 1.6.0
-Author: Houke de Kwant
-Author URI: ttps://github.com/houke/
+Version: 2.0.0
 Author: Houke de Kwant, NewCity
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
-GitHub Plugin URI: https://github.com/houke/acf-icon-picker
 GitHub Plugin URI: chttps://github.com/newcity/acf-icon-picker
 GitHub Branch: master
 */
@@ -26,7 +22,7 @@ class nc_acf_plugin_icon_picker {
 	function __construct() {
 
 		$this->settings = array(
-			'version'	=> '1.6.0',
+			'version'	=> '2.0.0',
 			'url'		=> plugin_dir_url( __FILE__ ),
 			'path'		=> plugin_dir_path( __FILE__ )
 		);

--- a/acf-icon-picker.php
+++ b/acf-icon-picker.php
@@ -14,9 +14,10 @@ GitHub Branch: master
 
 if( ! defined( 'ABSPATH' ) ) exit;
 
-if( !class_exists('acf_plugin_icon_picker') ) :
+if( !class_exists('nc_acf_plugin_icon_picker') ) :
 
-class acf_plugin_icon_picker {
+class nc_acf_plugin_icon_picker {
+	
 	protected $settings;
 
 	function __construct() {
@@ -27,7 +28,7 @@ class acf_plugin_icon_picker {
 			'path'		=> plugin_dir_path( __FILE__ )
 		);
 
-		add_action('acf/include_field_types', 	array($this, 'include_field_types'));
+		add_action('acf/include_field_types', array($this, 'include_field_types'));
 
 	}
 
@@ -37,6 +38,6 @@ class acf_plugin_icon_picker {
 
 }
 
-new acf_plugin_icon_picker();
+new nc_acf_plugin_icon_picker();
 
 endif;

--- a/acf-icon-picker.php
+++ b/acf-icon-picker.php
@@ -17,6 +17,7 @@ if( ! defined( 'ABSPATH' ) ) exit;
 if( !class_exists('acf_plugin_icon_picker') ) :
 
 class acf_plugin_icon_picker {
+	protected $settings;
 
 	function __construct() {
 

--- a/acf-icon-picker.php
+++ b/acf-icon-picker.php
@@ -2,13 +2,16 @@
 /*
 Plugin Name: Advanced Custom Fields: Icon Picker
 Plugin URI: https://github.com/houke/acf-icon-picker
+Plugin URI: https://github.com/newcity/acf-icon-picker
 Description: Allows you to pick an icon from a predefined list
 Version: 1.6.0
 Author: Houke de Kwant
 Author URI: ttps://github.com/houke/
+Author: Houke de Kwant, NewCity
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 GitHub Plugin URI: https://github.com/houke/acf-icon-picker
+GitHub Plugin URI: chttps://github.com/newcity/acf-icon-picker
 GitHub Branch: master
 */
 

--- a/assets/js/input.js
+++ b/assets/js/input.js
@@ -1,42 +1,43 @@
-(function($) {
+(function ($) {
   var active_item;
   var item_width = 125;
   var item_height = 116 + 6;
   var recycled_items = [];
 
-  jQuery(document).on('click', 'li[data-svg]', function() {
-    var val = jQuery(this).attr('data-svg');
-    active_item.find('input').val(val);
-    active_item.find('.acf-icon-picker__svg').html(
-      '<img src="' +
-        jQuery(this)
-          .find('img')
-          .attr('src') +
-        '" alt=""/>'
-    );
-    jQuery('.acf-icon-picker__popup-holder').trigger('close');
-    jQuery('.acf-icon-picker__popup-holder').remove();
+  jQuery(document).on("click", "li[data-svg]", function () {
+    var val = {};
+    val["icon"] = jQuery(this).attr("data-svg");
+    val["url"] = jQuery(this).find("img").first().attr("src");
+    var val_att = JSON.stringify(val);
+    active_item.find("input").val(val_att);
+    active_item
+      .find(".acf-icon-picker__svg")
+      .html('<img src="' + jQuery(this).find("img").attr("src") + '" alt=""/>');
+    jQuery(".acf-icon-picker__popup-holder").trigger("close");
+    jQuery(".acf-icon-picker__popup-holder").remove();
 
     active_item
-      .parents('.acf-icon-picker')
-      .find('.acf-icon-picker__remove')
-      .addClass('acf-icon-picker__remove--active');
+      .parents(".acf-icon-picker")
+      .find(".acf-icon-picker__remove")
+      .addClass("acf-icon-picker__remove--active");
   });
 
   function initialize_field($el) {
-    $el.find('.acf-icon-picker__img').on('click', function(e) {
+    console.log("initialize_field", $el);
+    $el.find(".acf-icon-picker__img").on("click", function (e) {
       e.preventDefault();
+      console.log("click");
       var is_open = true;
       active_item = $(this);
 
       if (iv.svgs.length == 0) {
-        var list = '<p>' + iv.no_icons_msg + '</p>';
+        var list = "<p>" + iv.no_icons_msg + "</p>";
       } else {
         var list = `<ul id="icons-list">`;
         list += `</ul>`;
       }
 
-      jQuery('body').append(
+      jQuery("body").append(
         `<div class="acf-icon-picker__popup-holder">
         <div class="acf-icon-picker__popup">
         <a class="acf-icon-picker__popup__close" href="javascript:">close</a>
@@ -47,11 +48,11 @@
       </div>`
       );
 
-      jQuery('.acf-icon-picker__popup-holder').on('close', function() {
+      jQuery(".acf-icon-picker__popup-holder").on("close", function () {
         is_open = false;
       });
 
-      var $list = $('#icons-list');
+      var $list = $("#icons-list");
       var margin = 200; // number of px to show above and below.
       var columns = 4;
       var svgs = iv.svgs;
@@ -62,7 +63,7 @@
       }
 
       function removeAllItems() {
-        $('[data-acf-icon-index]').each(function(i, el) {
+        $("[data-acf-icon-index]").each(function (i, el) {
           var $el = $(el);
           recycled_items.push($el);
           $el.remove();
@@ -72,24 +73,25 @@
       function render() {
         if (!is_open) return;
 
-        var scroll_top = $('.acf-icon-picker__popup').scrollTop();
+        var scroll_top = $(".acf-icon-picker__popup").scrollTop();
         var scroll_min = scroll_top - item_height - margin;
-        var scroll_max = scroll_top + $('.acf-icon-picker__popup').height() + margin;
+        var scroll_max =
+          scroll_top + $(".acf-icon-picker__popup").height() + margin;
         // Get the index of the first and last element from array we will show.
         var index_min = Math.ceil(scroll_min / item_height) * columns;
         var index_max = Math.ceil(scroll_max / item_height) * columns;
 
         // remove unneeded items and add them to recycled items.
-        $('[data-acf-icon-index]').each(function(i, el) {
+        $("[data-acf-icon-index]").each(function (i, el) {
           var $el = $(el);
-          var index = $el.attr('data-acf-icon-index');
-          var name = $el.attr('data-svg');
+          var index = $el.attr("data-acf-icon-index");
+          var name = $el.attr("data-svg");
           // Check if we have the element in the resulting array.
-          var elementExist = function() {
+          var elementExist = function () {
             return svgs.find(function (svg) {
               return svg.name === name;
             });
-          }
+          };
 
           if (index < index_min || index > index_max || !elementExist()) {
             recycled_items.push($el);
@@ -102,7 +104,7 @@
           var svg = svgs[i];
           // Calculate the position of the item.
           var y = Math.floor(i / columns) * item_height;
-          var x = i % columns * item_width;
+          var x = (i % columns) * item_width;
 
           // If we already have the element visible we can continue
           var $el = $(`[data-acf-icon-index="${i}"][data-svg="${svg.name}"]`);
@@ -112,8 +114,7 @@
           if (recycled_items.length) {
             // If there are recycled items reuse one.
             $el = recycled_items.pop();
-          }
-          else {
+          } else {
             // Or create a new element.
             $el = $(`<li>
               <div class="acf-icon-picker__popup-svg">
@@ -124,17 +125,20 @@
           }
 
           // We use attr instead of data since we want to use css selector.
-          $el.attr({
-            'data-svg': svg.name,
-            'data-acf-icon-index': i
-          }).css({
-            transform: `translate(${x}px, ${y}px)`
-          });
-          $el.find('.icons-list__name').text(svg['name'].replace(
-            /[-_]/g,
-            ' '
-          ));
-          $el.find('img').attr('src', `${iv.path}${svg['icon']}`);
+          $el
+            .attr({
+              "data-svg": svg.name,
+              "data-acf-icon-index": i,
+            })
+            .css({
+              transform: `translate(${x}px, ${y}px)`,
+            });
+          $el.find(".icons-list__name").text(svg["name"].replace(/[-_]/g, " "));
+          let location = iv.path;
+          if (svg["location"] === "parent") {
+            location = iv.parent_path;
+          }
+          $el.find("img").attr("src", `${location}${svg["icon"]}`);
           $list.append($el);
         }
 
@@ -145,12 +149,12 @@
         render();
       }
 
-      const iconsFilter = document.querySelector('#filterIcons');
+      const iconsFilter = document.querySelector("#filterIcons");
 
       function filterIcons(wordToMatch) {
-        return iv.svgs.filter(icon => {
-          var name = icon.name.replace(/[-_]/g, ' ');
-          const regex = new RegExp(wordToMatch, 'gi');
+        return iv.svgs.filter((icon) => {
+          var name = icon.name.replace(/[-_]/g, " ");
+          const regex = new RegExp(wordToMatch, "gi");
           return name.match(regex);
         });
       }
@@ -163,42 +167,49 @@
 
       iconsFilter.focus();
 
-      iconsFilter.addEventListener('keyup', displayResults);
+      iconsFilter.addEventListener("keyup", displayResults);
 
       // Closing
-      jQuery('.acf-icon-picker__popup__close').on('click', function(e) {
+      jQuery(".acf-icon-picker__popup__close").on("click", function (e) {
         e.stopPropagation();
         is_open = false;
-        jQuery('.acf-icon-picker__popup-holder').remove();
+        jQuery(".acf-icon-picker__popup-holder").remove();
       });
     });
 
     // show the remove button if there is an icon selected
-    if ($el.find('input').val().length != 0) {
+    if ($el.find("input").val().length != 0) {
       $el
-        .find('.acf-icon-picker__remove')
-        .addClass('acf-icon-picker__remove--active');
+        .find(".acf-icon-picker__remove")
+        .addClass("acf-icon-picker__remove--active");
     }
 
-    $el.find('.acf-icon-picker__remove').on('click', function(e) {
+    $el.find(".acf-icon-picker__remove").on("click", function (e) {
       e.preventDefault();
-      var parent = $(this).parents('.acf-icon-picker');
-      parent.find('input').val('');
+      var parent = $(this).parents(".acf-icon-picker");
+      parent.find("input").val("");
       parent
-        .find('.acf-icon-picker__svg')
+        .find(".acf-icon-picker__svg")
         .html('<span class="acf-icon-picker__svg--span">+</span>');
 
       parent
-        .find('.acf-icon-picker__remove')
-        .removeClass('acf-icon-picker__remove--active');
+        .find(".acf-icon-picker__remove")
+        .removeClass("acf-icon-picker__remove--active");
     });
   }
 
-  if (typeof acf.add_action !== 'undefined') {
-    acf.add_action('ready append', function($el) {
-      acf.get_fields({ type: 'icon_picker' }, $el).each(function() {
-        initialize_field($(this));
-      });
+  if (typeof acf.add_action !== "undefined") {
+    acf.add_action("ready append", function ($el) {
+      acf
+        .get_fields(
+          {
+            type: "nc_acf_icon_picker",
+          },
+          $el
+        )
+        .each(function () {
+          initialize_field($(this));
+        });
     });
   }
 })(jQuery);

--- a/fields/acf-icon-picker-v5.php
+++ b/fields/acf-icon-picker-v5.php
@@ -2,15 +2,15 @@
 
 if( ! defined( 'ABSPATH' ) ) exit;
 
-if( !class_exists('acf_field_icon_picker') ) :
+if( !class_exists('nc_acf_field_icon_picker') ) :
 
-class acf_field_icon_picker extends acf_field {
+class nc_acf_field_icon_picker extends acf_field {
 
 	function __construct( $settings ) {
 
-		$this->name = 'icon-picker';
+		$this->name = 'nc-acf-icon-picker';
 
-		$this->label = __('Icon Picker', 'acf-icon-picker');
+		$this->label = __('NC Icon Picker', 'acf-icon-picker');
 
 		$this->category = 'jquery';
 
@@ -25,6 +25,7 @@ class acf_field_icon_picker extends acf_field {
 		$this->settings = $settings;
 
 		$this->path_suffix = apply_filters( 'acf_icon_path_suffix', 'assets/img/acf/' );
+		$this->path_suffix = apply_filters( 'nc_acf_icon_path_suffix', 'assets/img/acf/' );
 
 		$this->path = $this->settings['path'] . $this->path_suffix;
 
@@ -101,7 +102,7 @@ class acf_field_icon_picker extends acf_field {
 		wp_enqueue_style('acf-input-icon-picker');
 	}
 }
-new acf_field_icon_picker( $this->settings );
+new nc_acf_field_icon_picker( $this->settings );
 
 endif;
 

--- a/fields/acf-icon-picker-v5.php
+++ b/fields/acf-icon-picker-v5.php
@@ -24,31 +24,71 @@ class nc_acf_field_icon_picker extends acf_field {
 
 		$this->settings = $settings;
 
-		$this->path_suffix = apply_filters( 'acf_icon_path_suffix', 'assets/img/acf/' );
 		$this->path_suffix = apply_filters( 'nc_acf_icon_path_suffix', 'assets/img/acf/' );
+		$this->parent_path_suffix = apply_filters( 'nc_acf_icon_parent_path_suffix', false );
 
-		$this->path = $this->settings['path'] . $this->path_suffix;
-
-		$this->url = $this->settings['url'] . $this->path_suffix;
-
-		$priority_dir_lookup = get_stylesheet_directory() . '/' . $this->path_suffix;
-
-		if ( file_exists( $priority_dir_lookup ) ) {
-			$this->path = $priority_dir_lookup;
-			$this->url = get_stylesheet_directory_uri() . '/' . $this->path_suffix;
+		if (! $this->parent_path_suffix ) {
+			$this->parent_path_suffix = $this->path_suffix;
 		}
+
+		$this->path = get_stylesheet_directory() . '/' . $this->path_suffix;
+
+		if ( is_dir( $this->path ) ) {
+			$this->url = get_stylesheet_directory_uri() . '/' . $this->path_suffix;
+		} else {
+			$this->path = $this->settings['path'] . $this->path_suffix;
+			$this->url = $this->settings['url'] . $this->path_suffix;
+		}
+
+		if ($this->parent_path_suffix) {
+			$this->parent_path = get_template_directory() . '/' . $this->parent_path_suffix;
+		}
+		if ( isset($this->parent_path) && is_dir( $this->parent_path ) ) {
+			$this->parent_url = get_template_directory_uri() . '/' . $this->path_suffix;
+		} else {
+			$this->parent_path = false;
+			$this->parent_url = false;
+		}
+
 
 		$this->svgs = array();
 
-		$files = array_diff(scandir($this->path), array('.', '..'));
-		foreach ($files as $file) {
-			if( pathinfo($file, PATHINFO_EXTENSION) == 'svg' ){
-				$exploded = explode('.', $file);
-				$icon = array(
-					'name' => $exploded[0],
-					'icon' => $file
-				);
-				array_push($this->svgs, $icon);
+		$is_path = is_dir($this->path);
+		
+		$files = is_dir($this->path) ? scandir($this->path) : array();
+		$files = array_map(function ($file) {
+			return $this->path . $file;
+		}, $files);
+		
+		$parent_files = is_dir($this->parent_path) ? scandir($this->parent_path) : array();
+		$parent_files = array_map(function ($file) {
+			if ( in_array ($file, array('.', '..'))) {
+				return $file;
+			}
+			return $this->parent_path . $file;
+		}, $parent_files);
+		
+		$files = array_replace($parent_files, $files);
+
+		if (count($files)) {
+			
+			$files = array_diff($files, array('.', '..'));
+			foreach ($files as $file) {
+				if( pathinfo($file, PATHINFO_EXTENSION) == 'svg' ){
+					$name = basename($file, '.svg');
+					$icon = array(
+						'name' => $name,
+						'icon' => $name . '.svg'
+					);
+
+					$icon_location = strpos($file, $this->parent_path) !== false ? 'parent' : 'current';
+
+					$icon['location'] = $icon_location;
+
+					if ($icon_location !== 'parent' || ! file_exists($this->path . $name . '.svg')) {
+						array_push($this->svgs, $icon);
+					}
+				}
 			}
 		}
 
@@ -56,16 +96,41 @@ class nc_acf_field_icon_picker extends acf_field {
 	}
 
 	function render_field( $field ) {
-		$input_icon = $field['value'] != "" ? $field['value'] : $field['initial_value'];
-		$svg = $this->path . $input_icon . '.svg';
+		$input_value = $field['value'] != "" ? $field['value'] : $field['initial_value'];
+		$input_array = json_decode($input_value, JSON_OBJECT_AS_ARRAY);
+		$svg = array();
+		if ($input_array === NULL) {
+			if ($input_value) {
+				$input_array = array(
+					'icon' => $input_value
+				);
+			}
+		}
+		if (isset($input_array['icon'])) {
+			$svg['icon'] = basename($input_array['icon'], '.svg');
+			$svg['path'] = $this->path . $svg['icon'] . '.svg';
+			if (file_exists($svg['path'])) {
+				$svg['url'] = $this->url . $svg['icon'] . '.svg';
+				$svg['location'] = 'current';
+			}
+			elseif ( $this->parent_path ) {
+				$svg['path'] = $this->parent_path . $svg['icon'] . '.svg';
+				$svg['url'] = $this->parent_url . $svg['icon'] . '.svg';
+				$svg['location'] = 'parent';
+			}
+
+			$svg_encoded = json_encode($svg);
+		} else {
+			$svg_encoded = null;
+		}
+		
 		?>
 			<div class="acf-icon-picker">
 				<div class="acf-icon-picker__img">
 					<?php
-						if ( file_exists( $svg ) ) {
-							$svg = $this->url . $input_icon . '.svg';
+						if ( isset( $svg['path'] ) && file_exists( $svg['path'] ) ) {
 							echo '<div class="acf-icon-picker__svg">';
-						   	echo '<img src="'.$svg.'" alt=""/>';
+						   	echo '<img src="'.$svg['url'].'" alt=""/>';
 						    echo '</div>';
 						}else{
 							echo '<div class="acf-icon-picker__svg">';
@@ -73,7 +138,7 @@ class nc_acf_field_icon_picker extends acf_field {
 						    echo '</div>';
 						}
 					?>
-					<input type="hidden" readonly name="<?php echo esc_attr($field['name']) ?>" value="<?php echo esc_attr($input_icon) ?>"/>
+					<input type="hidden" readonly name="<?php echo esc_attr($field['name']) ?>" value='<?php echo $svg_encoded ?>'/>
 				</div>
 				<?php if ( $field['required' ] == false ) { ?>
 					<span class="acf-icon-picker__remove">
@@ -94,6 +159,7 @@ class nc_acf_field_icon_picker extends acf_field {
 
 		wp_localize_script( 'acf-input-icon-picker', 'iv', array(
 			'path' => $this->url,
+			'parent_path' => $this->parent_url,
 			'svgs' => $this->svgs,
 			'no_icons_msg' => sprintf( esc_html__('To add icons, add your svg files in the /%s folder in your theme.', 'acf-icon-picker'), $this->path_suffix)
 		) );

--- a/fields/acf-icon-picker-v5.php
+++ b/fields/acf-icon-picker-v5.php
@@ -24,7 +24,7 @@ class nc_acf_field_icon_picker extends acf_field {
 
 		$this->settings = $settings;
 
-		$this->path_suffix = apply_filters( 'nc_acf_icon_path_suffix', 'assets/img/acf/' );
+		$this->path_suffix = apply_filters( 'nc_acf_icon_path_suffix', 'images/svg-icons' );
 		$this->parent_path_suffix = apply_filters( 'nc_acf_icon_parent_path_suffix', false );
 
 		if (! $this->parent_path_suffix ) {


### PR DESCRIPTION
- Changed the field type name from `icon-picker` to `nc-acf-icon-picker` and updated its label from "Icon Picker" to "NC Icon Picker". Anywhere that you have set up an icon picker field using this plugin, you must change the field's `type` value to `nc-acf-icon-picker`. If a field group is stored in code as JSON or PHP, you can make this change by changing the `type` value directly. If you are managing the field group directly within the ACF settings in WordPress, you will need to change the type to "NC Icon Picker".

- Changed the default path to icon files to `images/svg-icons/`. If you were using the old version of the plugin without modifying the path, you need to use the `nc_acf_icon_path_suffix` hook in your theme to change the path back to its old value (`assets/img/acf/`)

- Introduced parent/child theme support. Consult the "Parent / Child Theme Icons" section of this ReadMe for details on how to use this new feature.