### PR TITLE
Formatting options

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ This conversion is not backwards-compatible. Any icon values saved using this pl
 
 ## Changelog
 
+- 2.1.1 - Fixed bug where existing string values were not returned correctly with the `string` formatter.
+
 - 2.1.0 - Added `nc_acf_icon_picker_format_type` filter. For details, see the ReadMe under "Filters > Setting the Output Format"
 
 - 2.0.1 - Added a deprecation notice for the old `acf_icon_path_suffix` filter hook. This hook was already deprecated, but the change was not documented and no warning was provided. Please update all references from `acf_icon_path_suffix` to `nc_acf_icon_path_suffix`.

--- a/acf-icon-picker.php
+++ b/acf-icon-picker.php
@@ -3,7 +3,7 @@
 Plugin Name: Advanced Custom Fields: Icon Picker
 Plugin URI: https://github.com/newcity/acf-icon-picker
 Description: Allows you to pick an icon from a predefined list
-Version: 2.1.0
+Version: 2.1.1
 Author: Houke de Kwant, NewCity
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "newcity/acf-icon-picker",
   "type": "wordpress-plugin",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "require": {
     "composer/installers": "^1.0.0"
   }

--- a/fields/acf-icon-picker-v5.php
+++ b/fields/acf-icon-picker-v5.php
@@ -124,7 +124,7 @@ class nc_acf_field_icon_picker extends acf_field {
 				return $parsed_value['icon'];
 			}
 			if ( is_string( $value ) ) {
-				return $parsed_value;
+				return $value;
 			}
 			return '';
 		}


### PR DESCRIPTION
Fixed bug where existing string values were not returned correctly with the `string` formatter.