### PR TITLE
Fix an error when no icon selected

### DIFF
--- a/assets/js/input.js
+++ b/assets/js/input.js
@@ -176,7 +176,8 @@
     });
 
     // show the remove button if there is an icon selected
-    if ($el.find('input').val().length != 0) {
+    const inputVal = $el.find('input').val();
+    if (inputVal && inputVal.length != 0) {
       $el
         .find('.acf-icon-picker__remove')
         .addClass('acf-icon-picker__remove--active');


### PR DESCRIPTION
This threw errors when the input.js script was loaded the field was not present. New code checks for presence of a value before trying to get the value's length